### PR TITLE
Add QA progress and Playwright tests

### DIFF
--- a/agent-ai-app-factory-finalized-6/agents/qa.ts
+++ b/agent-ai-app-factory-finalized-6/agents/qa.ts
@@ -2,6 +2,13 @@ import { exec } from 'child_process';
 import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'fs';
 import { tmpdir } from 'os';
 import path from 'path';
+import { improveCodebase } from './codeGeneration';
+
+interface TestResult {
+  output: string;
+  success: boolean;
+  code: Record<string, string>;
+}
 
 /**
  * Run automated tests on a generated codebase.
@@ -12,30 +19,75 @@ import path from 'path';
  *
  * @param code Map of file paths to contents representing the generated app
  */
-export async function runTests(code: Record<string, string>): Promise<string> {
-  const tempRoot = mkdtempSync(path.join(tmpdir(), 'ai-app-'));
-  // Write files to disk
-  for (const [filePath, content] of Object.entries(code)) {
-    const dest = path.join(tempRoot, filePath);
-    // ensure directory exists
-    const dir = path.dirname(dest);
-    mkdirSync(dir, { recursive: true });
-    writeFileSync(dest, content, 'utf8');
+export async function runTests(
+  code: Record<string, string>,
+  onProgress?: (msg: string) => void,
+  retryLimit = 2
+): Promise<TestResult> {
+  let attempt = 0;
+  let currentCode = code;
+  let combinedOutput = '';
+
+  while (attempt <= retryLimit) {
+    const { output, success } = await runOnce(currentCode, onProgress);
+    combinedOutput += `--- Attempt ${attempt + 1} ---\n` + output + '\n';
+
+    if (success) {
+      return { output: combinedOutput, success: true, code: currentCode };
+    }
+
+    attempt++;
+    if (attempt > retryLimit) break;
+    onProgress?.('Tests failed. Sending diagnostics to code generation agent...');
+    currentCode = await improveCodebase(currentCode, output);
   }
-  // Install dependencies and run tests
-  const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
-  const execAsync = (cmd: string, cwd: string) => new Promise<string>((resolve, reject) => {
-    exec(cmd, { cwd }, (err, stdout, stderr) => {
-      if (err) reject(new Error(stderr || stdout));
-      else resolve(stdout + stderr);
-    });
-  });
-  let output = '';
+
+  return { output: combinedOutput, success: false, code: currentCode };
+}
+
+async function runOnce(
+  code: Record<string, string>,
+  onProgress?: (msg: string) => void
+): Promise<{ output: string; success: boolean }> {
+  const tempRoot = mkdtempSync(path.join(tmpdir(), 'ai-app-'));
   try {
-    output += await execAsync(`${npm} install --omit=optional`, tempRoot);
-    output += await execAsync(`${npm} test -- --runInBand`, tempRoot);
+    for (const [filePath, content] of Object.entries(code)) {
+      const dest = path.join(tempRoot, filePath);
+      const dir = path.dirname(dest);
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(dest, content, 'utf8');
+    }
+
+    const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+    const execAsync = (cmd: string) =>
+      new Promise<{ out: string; ok: boolean }>((resolve) => {
+        exec(cmd, { cwd: tempRoot }, (err, stdout, stderr) => {
+          resolve({ out: stdout + stderr, ok: !err });
+        });
+      });
+
+    onProgress?.('Installing dependencies...');
+    const install = await execAsync(`${npm} install --omit=optional`);
+    let output = install.out;
+    if (!install.ok) {
+      return { output, success: false };
+    }
+
+    onProgress?.('Running Jest tests...');
+    const jest = await execAsync(`${npm} test -- --runInBand`);
+    output += jest.out;
+    if (!jest.ok) {
+      return { output, success: false };
+    }
+
+    onProgress?.('Running Playwright tests...');
+    const pwInstall = await execAsync(`npx playwright install`);
+    output += pwInstall.out;
+    const pw = await execAsync(`npx playwright test --reporter line`);
+    output += pw.out;
+
+    return { output, success: pw.ok };
   } finally {
     rmSync(tempRoot, { recursive: true, force: true });
   }
-  return output;
 }


### PR DESCRIPTION
## Summary
- support iterative fixes in `runTests` and also run Playwright
- expose QA job progress in the backend
- poll QA endpoint from the frontend QA page
- allow code generation agent to improve code on failures

## Testing
- `npm -w backend run build` *(fails: Cannot find name 'process', TS errors)*
- `npm -w frontend run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68854f8c9c40832fa7351d44fde2b3cd