### PR TITLE
Add zip packaging for deployments

### DIFF
--- a/agent-ai-app-factory-finalized-6/backend/package.json
+++ b/agent-ai-app-factory-finalized-6/backend/package.json
@@ -8,17 +8,18 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
+    "@octokit/rest": "^20.0.0",
+    "@prisma/client": "^5.0.0",
+    "@supabase/supabase-js": "^2.0.0",
+    "@vercel/client": "^15.3.13",
+    "archiver": "^7.0.1",
     "axios": "^1.6.0",
     "cheerio": "^1.0.0-rc.12",
     "cors": "^2.8.5",
     "express": "^4.18.2",
+    "google-trends-api": "^4.9.2",
     "openai": "^4.14.0",
-    "prisma": "^5.0.0",
-    "@prisma/client": "^5.0.0",
-    "@supabase/supabase-js": "^2.0.0",
-    "@octokit/rest": "^20.0.0",
-    "@vercel/client": "^15.3.13",
-    "google-trends-api": "^4.9.2"
+    "prisma": "^5.0.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.17",

--- a/agent-ai-app-factory-finalized-6/frontend/pages/deploy.tsx
+++ b/agent-ai-app-factory-finalized-6/frontend/pages/deploy.tsx
@@ -12,7 +12,7 @@ export default function DeployPage() {
   const [repoName, setRepoName] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [result, setResult] = useState<{ repoUrl: string; liveUrl: string } | null>(null);
+  const [result, setResult] = useState<{ repoUrl: string; liveUrl: string; zipBase64: string } | null>(null);
 
   // Load generated code from localStorage
   function loadCode(): Record<string, string> | null {
@@ -94,6 +94,16 @@ export default function DeployPage() {
             Live URL: {' '}
             <a href={result.liveUrl} className="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">
               {result.liveUrl}
+            </a>
+          </p>
+          <p>
+            Download ZIP:{' '}
+            <a
+              href={`data:application/zip;base64,${result.zipBase64}`}
+              download="workspace.zip"
+              className="text-blue-600 hover:underline"
+            >
+              workspace.zip
             </a>
           </p>
           <Link


### PR DESCRIPTION
## Summary
- package workspace code into a zip after deployment
- include the base64 zip data in deployment API response
- link to the zip download on the deploy page
- install `archiver` for backend

## Testing
- `npx tsc -p backend` *(fails: Could not find types / modules)*

------
https://chatgpt.com/codex/tasks/task_e_688551bf3fac832f808a4b967ed759cc