### PR TITLE
Update OpenAI initialization

### DIFF
--- a/agent-ai-app-factory-finalized-6/agents/codeGeneration.ts
+++ b/agent-ai-app-factory-finalized-6/agents/codeGeneration.ts
@@ -3,7 +3,7 @@ import { Specification } from './specification';
 
 // Set up OpenAI client with API key from environment
 const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY || '',
+  apiKey: process.env.OPENAI_API_KEY,
 });
 
 /**

--- a/agent-ai-app-factory-finalized-6/agents/marketplace.ts
+++ b/agent-ai-app-factory-finalized-6/agents/marketplace.ts
@@ -13,7 +13,7 @@ interface Listing {
 }
 
 const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY || '',
+  apiKey: process.env.OPENAI_API_KEY,
 });
 
 /**

--- a/agent-ai-app-factory-finalized-6/agents/specification.ts
+++ b/agent-ai-app-factory-finalized-6/agents/specification.ts
@@ -12,7 +12,7 @@ export interface Specification {
 // Initialise an OpenAI client using the API key from the environment.  The
 // environment variable OPENAI_API_KEY must be set when running the backend.
 const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY || '',
+  apiKey: process.env.OPENAI_API_KEY,
 });
 
 /**

--- a/agent-ai-app-factory-finalized-6/backend/tsconfig.json
+++ b/agent-ai-app-factory-finalized-6/backend/tsconfig.json
@@ -7,7 +7,7 @@
     "esModuleInterop": true,
     "strict": true,
     "skipLibCheck": true,
-    "types": ["node"]
+    "types": ["node", "jest"]
   },
   "include": ["src/**/*", "../agents/**/*"]
 }


### PR DESCRIPTION
## Summary
- use `import OpenAI from 'openai'`
- initialize OpenAI with just `process.env.OPENAI_API_KEY`
- enable Jest type definitions for backend tests

## Testing
- `npm test --workspaces`

------
https://chatgpt.com/codex/tasks/task_e_6885dcb5f9c4832fb3f170421b390988