### PR TITLE
Add Apify token support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,8 @@ SUPABASE_URL=your-supabase-url
 SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key
 ENVATO_TOKEN=your-envato-token
 REDDIT_USER_AGENT=your-reddit-user-agent
+# Token used to access the Apify Flippa actor
+APIFY_API_TOKEN=
 # Port for the backend server
 PORT=4000
 # Personal Flippa token used to create listings

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Key variables include:
 
 - `FLIPPA_API_KEY` – the personal API token used to create listings on Flippa. Generate this key from your Flippa account and place it in the `.env` file.
 - `FLIPPA_API_URL` – the base URL of the Flippa listing API. The default `https://api.flippa.com/v3/listings` works for production but can be adjusted if Flippa provides an alternative endpoint.
+- `APIFY_API_TOKEN` – token for the Apify Flippa actor used by the market research agent to fetch listings.
 - `INTERNAL_MARKETPLACE_URL` – the root address of your internal marketplace where generated apps are published. Set it to your own marketplace’s URL in the `.env` file.
 - `NEXT_PUBLIC_API_BASE_URL` – base URL used by the frontend to reach the backend API. Defaults to `http://localhost:4000` for local development.
 

--- a/agent-ai-app-factory-finalized-6/README.md
+++ b/agent-ai-app-factory-finalized-6/README.md
@@ -16,6 +16,7 @@ Agents live in the top‑level `agents` directory so they can be imported by bot
 - An OpenAI API key and access to a Supabase/PostgreSQL database
 
 Other environment variables are optional but recommended for deployment and marketplace integrations. See `.env.example` for the full list.
+The `APIFY_API_TOKEN` variable allows the market research agent to query the Apify Flippa actor for current listings.
 
 ## Installation
 

--- a/agent-ai-app-factory-finalized-6/backend/src/__tests__/scrapeFlippa.test.ts
+++ b/agent-ai-app-factory-finalized-6/backend/src/__tests__/scrapeFlippa.test.ts
@@ -1,0 +1,29 @@
+import { scrapeFlippa } from '../../../agents/marketResearch';
+import axios from 'axios';
+
+jest.mock('axios');
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('scrapeFlippa', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.APIFY_API_TOKEN;
+  });
+
+  it('throws when token missing', async () => {
+    await expect(scrapeFlippa()).rejects.toThrow('Missing APIFY_API_TOKEN');
+  });
+
+  it('fetches listings from Apify', async () => {
+    process.env.APIFY_API_TOKEN = 't';
+    mockedAxios.get.mockResolvedValue({ data: [
+      { title: 'A', description: 'd', price: 1, url: 'u' }
+    ] });
+    const ideas = await scrapeFlippa();
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      expect.stringContaining('actor-tasks/apify~flippa/run-sync-get-dataset-items?token=t')
+    );
+    expect(ideas[0].title).toBe('A');
+  });
+});


### PR DESCRIPTION
## Summary
- support `APIFY_API_TOKEN` in `.env.example`
- document token usage in both READMEs
- fetch Flippa listings via Apify in `scrapeFlippa`
- add tests for `scrapeFlippa`

## Testing
- `npm --workspace backend test`

------
https://chatgpt.com/codex/tasks/task_e_6885fc710490832fa48265d334e11441