### PR TITLE
Add production build docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,22 @@ $$ language sql;
 Ensure your database has an `analytics` table with `app_id`, `user_id` and
 `page_views` columns or adjust the query accordingly.
 
+### Building for production
+
+Build the backend and frontend before deploying:
+
+```bash
+# Backend
+cd backend
+npm run build
+
+# Frontend
+cd ../frontend
+npm run build
+```
+
+After building you can start each service with `npm start`.
+
 ### License
 
 Released under the [MIT](LICENSE) license.

--- a/agent-ai-app-factory-finalized-6/backend/package.json
+++ b/agent-ai-app-factory-finalized-6/backend/package.json
@@ -27,6 +27,7 @@
     "@types/express": "^4.17.17",
     "@types/jest": "^29.5.4",
     "@types/node": "^20.17.1",
+    "@types/cors": "^2.8.19",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",

--- a/agent-ai-app-factory-finalized-6/package-lock.json
+++ b/agent-ai-app-factory-finalized-6/package-lock.json
@@ -33,6 +33,7 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.41.2",
+        "@types/cors": "^2.8.19",
         "@types/express": "^4.17.17",
         "@types/jest": "^29.5.4",
         "@types/node": "^20.17.1",
@@ -1794,6 +1795,16 @@
       "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/express": {
       "version": "4.17.23",


### PR DESCRIPTION
## Summary
- document how to build backend and frontend for production
- include `@types/cors` devDependency for backend

## Testing
- `npm --workspace backend test`
- `npm --workspace frontend test`
- `npm --workspace backend run build`
- `npm --workspace frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_68881481a9f0832fa3cb276856ee053d